### PR TITLE
Show comments for columns in their tooltip, if available

### DIFF
--- a/viewer/src/sheet/schema_column.rs
+++ b/viewer/src/sheet/schema_column.rs
@@ -12,6 +12,7 @@ pub struct SchemaColumn(Rc<SchemaColumnImpl>);
 struct SchemaColumnImpl {
     name: String,
     meta: SchemaColumnMeta,
+    comment: Option<String>,
 }
 
 impl SchemaColumn {
@@ -21,6 +22,10 @@ impl SchemaColumn {
 
     pub fn meta(&self) -> &SchemaColumnMeta {
         &self.0.meta
+    }
+
+    pub fn comment(&self) -> Option<&str> {
+        self.0.comment.as_deref()
     }
 
     fn get_columns_inner(
@@ -86,7 +91,7 @@ impl SchemaColumn {
                     FieldType::Array => unreachable!(),
                 };
 
-                ret.push(Self::new(name, meta));
+                ret.push(Self::new(name, meta, field.comment.clone()));
             }
         }
 
@@ -133,7 +138,7 @@ impl SchemaColumn {
                     } else {
                         unreachable!();
                     }
-                    ret[i] = Self::new(name, meta);
+                    ret[i] = Self::new(name, meta, None);
                 } else {
                     unreachable!();
                 }
@@ -179,12 +184,16 @@ impl SchemaColumn {
 
     pub fn from_blank(column_count: u32) -> Vec<Self> {
         (0..column_count)
-            .map(|i| Self::new(format!("Column{}", i), SchemaColumnMeta::Scalar))
+            .map(|i| Self::new(format!("Column{}", i), SchemaColumnMeta::Scalar, None))
             .collect()
     }
 
-    pub fn new(name: String, meta: SchemaColumnMeta) -> Self {
-        Self(Rc::new(SchemaColumnImpl { name, meta }))
+    pub fn new(name: String, meta: SchemaColumnMeta, comment: Option<String>) -> Self {
+        Self(Rc::new(SchemaColumnImpl {
+            name,
+            meta,
+            comment,
+        }))
     }
 }
 

--- a/viewer/src/sheet/sheet_table.rs
+++ b/viewer/src/sheet/sheet_table.rs
@@ -474,7 +474,7 @@ impl TableDelegate for SheetTable {
             .show(ui, |ui| {
                 if let Some((column_id, (schema_column, sheet_column))) = column {
                     ui.heading(schema_column.name()).on_hover_text(format!(
-                        "Id: {}\nIndex: {}\nOffset: {}\nKind: {:?}{}",
+                        "Id: {}\nIndex: {}\nOffset: {}\nKind: {:?}{}{}",
                         sheet_column.id,
                         column_id,
                         sheet_column.offset(),
@@ -483,7 +483,11 @@ impl TableDelegate for SheetTable {
                             "\nDisplay Field"
                         } else {
                             ""
-                        }
+                        },
+                        schema_column
+                            .comment()
+                            .map(|x| format!("\nComment: {x}"))
+                            .unwrap_or_default(),
                     ));
                 } else {
                     ui.heading("Row");


### PR DESCRIPTION
These comments are invaluable for some of the harder-to-figure-out columns, so we should show them! This adds comments (if written in the schema) to the column tooltips.

![Screenshot_20250630_151811](https://github.com/user-attachments/assets/6091626a-5e8f-41ce-8545-3982226b9c95)
